### PR TITLE
Include non semantic tags logic on checking for udpates

### DIFF
--- a/src/image_checker.py
+++ b/src/image_checker.py
@@ -253,7 +253,7 @@ class ImageChecker:
         else:
             if ":" not in image_name or image_name.split(":")[1] == "latest":
                 status = False
-                msg = f"{image_name}: {self.redmine_error_color}can not check for updates to 'latest' tag%"
+                msg = f"{image_name}: {self.redmine_error_color}'latest' tag is not upgradeable%"
             else:
                 image, curr_version = image_name.split(":")
                 if self.non_semantic_version(curr_version):


### PR DESCRIPTION
Changes: for non semantic tags, we decided to retrieve from docker hub more details on tags (including update time). Because we won't be able to find similar tag flavours for non semantic versions, we will always return the last tag created as the upgrade for that image

Example:
```
INFO:eeacms/esbootstrap:112607: non semantic version tag
INFO:eeacms/sentry:114232-ldap: non semantic version tag
```
cu update
```
eeacms/esbootstrap:112607: non semantic version - upgrade to v3.0.22
eeacms/sentry:114232-ldap: non semantic version - upgrade to 9.2-1.0
```

The new container page looks like this: https://taskman.devel4cph.eea.europa.eu/projects/infrastructure/wiki/Rancher_containers